### PR TITLE
Create Page for Articles plus tests and stories

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,9 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -73,6 +76,21 @@ function App() {
             <>
               <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
               <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/articles" element={<ArticlesIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/articles/edit/:id" element={<ArticlesEditPage />} />
+              <Route exact path="/articles/create" element={<ArticlesCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Articles/ArticlesForm.js
+++ b/frontend/src/main/components/Articles/ArticlesForm.js
@@ -1,0 +1,146 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+function ArticlesForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    const testIdPrefix = "ArticlesForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        value={initialContents.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="title">Title</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-title"}
+                    id="title"
+                    type="text"
+                    isInvalid={Boolean(errors.title)}
+                    {...register("title", {
+                        required: "Title is required.",
+                        maxLength : {
+                            value: 50,
+                            message: "Max length 50 characters"
+                        }
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.title?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="url">URL</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-url"}
+                    id="url"
+                    type="text"
+                    isInvalid={Boolean(errors.url)}
+                    {...register("url", {
+                        required: "URL is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.url?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="explanation">Explanation</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-explanation"}
+                    id="explanation"
+                    type="text"
+                    isInvalid={Boolean(errors.explanation)}
+                    {...register("explanation", {
+                        required: "Explanation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.explanation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="email">Email</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-email"}
+                    id="email"
+                    type="text"
+                    isInvalid={Boolean(errors.email)}
+                    {...register("email", {
+                        required: "Email is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.email?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="dateAdded">Date (iso format)</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-dateAdded"}
+                    id="dateAdded"
+                    type="datetime-local"
+                    isInvalid={Boolean(errors.dateAdded)}
+                    {...register("dateAdded", { required: true, pattern: isodate_regex })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.dateAdded && 'LocalDateTime is required. '}
+                </Form.Control.Feedback>
+            </Form.Group>
+            
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default ArticlesForm;

--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -1,0 +1,70 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/articleUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function ArticlesTable({
+    articles,
+    currentUser,
+    testIdPrefix = "ArticlesTable" }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/articles/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/articles/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Title',
+            accessor: 'title',
+        },
+        {
+            Header: 'URL',
+            accessor: 'url',
+        },
+        {
+            Header: 'Explanation',
+            accessor: 'explanation',
+        },
+        {
+            Header: 'Email',
+            accessor: 'email',
+        },
+        {
+            Header: 'Date',
+            accessor: 'dateAdded',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
+    } 
+
+    return <OurTable
+        data={articles}
+        columns={columns}
+        testid={testIdPrefix}
+    />;
+};
+

--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -6,10 +6,7 @@ import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/articleUtil
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-export default function ArticlesTable({
-    articles,
-    currentUser,
-    testIdPrefix = "ArticlesTable" }) {
+export default function ArticlesTable({ articles, currentUser }) {
 
     const navigate = useNavigate();
 
@@ -57,14 +54,13 @@ export default function ArticlesTable({
     ];
 
     if (hasRole(currentUser, "ROLE_ADMIN")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
-        columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "ArticlesTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "ArticlesTable"));
     } 
 
     return <OurTable
         data={articles}
         columns={columns}
-        testid={testIdPrefix}
+        testid={"ArticlesTable"}
     />;
 };
-

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,6 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/articles">Articles</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,13 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
+export default function ArticlesCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
+    const objectToAxiosParams = (article) => ({
+        url: "/api/articles/post",
+        method: "POST",
+        params: {
+          title: article.title,
+          url: article.url,
+          explanation: article.explanation,
+          email: article.email,
+          dateAdded: article.dateAdded
+        }
+      });
+    
+      const onSuccess = (article) => {
+        toast(`New article Created - id: ${article.id} title: ${article.title}`);
+      }
+    
+      const mutation = useBackendMutation(
+        objectToAxiosParams,
+         { onSuccess }, 
+         // Stryker disable next-line all : hard to set up test for caching
+         ["/api/articles/all"]
+         );
+    
+      const { isSuccess } = mutation
+    
+      const onSubmit = async (data) => {
+        mutation.mutate(data);
+      }
+    
+      if (isSuccess && !storybook) {
+        return <Navigate to="/articles" />
+      }
+    
+      return (
+        <BasicLayout>
+          <div className="pt-2">
+            <h1>Create New Article</h1>
+    
+            <ArticlesForm submitAction={onSubmit} />
+    
+          </div>
+        </BasicLayout>
+      )
 }

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/articles/create">Create</a></p>
+        <p><a href="/articles/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/utils/articleUtils.js
+++ b/frontend/src/main/utils/articleUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/articles",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/components/Articles/ArticlesForm.stories.js
+++ b/frontend/src/stories/components/Articles/ArticlesForm.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import ArticlesForm from "main/components/Articles/ArticlesForm"
+import { articlesFixtures } from 'fixtures/articlesFixtures';
+
+export default {
+    title: 'components/Articles/ArticlesForm',
+    component: ArticlesForm
+};
+
+const Template = (args) => {
+    return (
+        <ArticlesForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+         console.log("Submit was clicked with data: ", data); 
+         window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: articlesFixtures.oneArticle,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/Articles/ArticlesTable.stories.js
+++ b/frontend/src/stories/components/Articles/ArticlesTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import ArticlesTable from "main/components/Articles/ArticlesTable";
+import { articlesFixtures } from 'fixtures/articlesFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/Articles/ArticlesTable',
+    component: ArticlesTable
+};
+
+const Template = (args) => {
+    return (
+        <ArticlesTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    articles: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    articles: articlesFixtures.threeArticles,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    articles: articlesFixtures.threeArticles,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/articles', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+    title: 'pages/Articles/ArticlesCreatePage',
+    component: ArticlesCreatePage
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/articles/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/components/Articles/ArticlesForm.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesForm.test.js
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("ArticlesForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Title", "URL", "Explanation", "Email", "Date (iso format)"];
+    const testId = "ArticlesForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ArticlesForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ArticlesForm initialContents={articlesFixtures.oneArticle} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+        expect(screen.getByText(`Id`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ArticlesForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test("that the correct validations are performed", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ArticlesForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Title is required/);
+        expect(screen.getByText(/URL is required/)).toBeInTheDocument();
+        expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+        expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+        expect(screen.getByText(/LocalDateTime is required/)).toBeInTheDocument();
+
+
+
+        const titleInput = screen.getByTestId(`${testId}-title`);
+        fireEvent.change(titleInput, { target: { value: "a".repeat(51) } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Max length 50 characters/)).toBeInTheDocument();
+        });
+    });
+
+    test("that the correct data-testids are present", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <ArticlesForm />
+                </Router>
+            </QueryClientProvider>
+        );
+    
+        const testIds = ["title", "url", "explanation", "email", "dateAdded", "submit", "cancel"];
+        
+        testIds.forEach((id) => {
+            expect(screen.getByTestId(`ArticlesForm-${id}`)).toBeInTheDocument();
+        });
+    });
+    
+
+});

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.js
@@ -4,14 +4,9 @@ import ArticlesTable from "main/components/Articles/ArticlesTable"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-import { toast } from "react-toastify";
-import { onDeleteSuccess } from "main/utils/articleUtils";
 
 const mockedNavigate = jest.fn();
 
-jest.mock("react-toastify", () => ({
-    toast: jest.fn(),
-}));
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
@@ -176,20 +171,6 @@ describe("ArticlesTable tests", () => {
     // act - click the delete button
     fireEvent.click(deleteButton);
   });
-});
-
-describe("onDeleteSuccess tests", () => {
-    it("logs the message and shows a toast notification", () => {
-        const mockMessage = "Delete successful!";
-        const logSpy = jest.spyOn(console, "log").mockImplementation();
-
-        onDeleteSuccess(mockMessage);
-
-        expect(logSpy).toHaveBeenCalledWith(mockMessage);
-        expect(toast).toHaveBeenCalledWith(mockMessage);
-
-        logSpy.mockRestore();
-    });
 });
 
 

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.js
@@ -1,0 +1,195 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import ArticlesTable from "main/components/Articles/ArticlesTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { toast } from "react-toastify";
+import { onDeleteSuccess } from "main/utils/articleUtils";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-toastify", () => ({
+    toast: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("ArticlesTable tests", () => {
+  const queryClient = new QueryClient();
+  const expectedHeaders = ["id", "Title", "URL", "Explanation", "Email", "Date"];
+  const expectedFields = ["id", "title", "url", "explanation", "email", "dateAdded"];
+  const testId = "ArticlesTable";
+
+  test("renders empty table correctly", () => {
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={articlesFixtures.threeArticles} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={articlesFixtures.threeArticles} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={articlesFixtures.threeArticles} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`ArticlesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const editButton = screen.getByTestId(`ArticlesTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/articles/edit/1'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={articlesFixtures.threeArticles} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent("How to use Spring Data JDBC with Spring Boot");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-url`)).toHaveTextContent("https://www.youtube.com/watch?v=l_T0nQNbFiM");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-explanation`)).toHaveTextContent("This is a great video that explains how to use Spring Data JDBC with Spring Boot");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-email`)).toHaveTextContent("andyouyang@ucsb.edu");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-dateAdded`)).toHaveTextContent("2022-04-21T00:00:00");
+
+
+
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+});
+
+describe("onDeleteSuccess tests", () => {
+    it("logs the message and shows a toast notification", () => {
+        const mockMessage = "Delete successful!";
+        const logSpy = jest.spyOn(console, "log").mockImplementation();
+
+        onDeleteSuccess(mockMessage);
+
+        expect(logSpy).toHaveBeenCalledWith(mockMessage);
+        expect(toast).toHaveBeenCalledWith(mockMessage);
+
+        logSpy.mockRestore();
+    });
+});
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticlesCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,62 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("ArticlesCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const article = {
+            id: 17,
+            title: "How to use Spring Data JDBC with Spring Boot",
+            url: "https://www.youtube.com/watch?v=l_T0nQNbFiM",
+            explanation: "This is a great video that explains how to use Spring Data JDBC with Spring Boot",
+            email: "andyouyang@ucsb.edu",
+            dateAdded: "2022-04-21T00:00"
+        };
+
+        axiosMock.onPost("/api/articles/post").reply( 202, article );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,9 +72,42 @@ describe("ArticlesCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("ArticlesForm-title")).toBeInTheDocument();
+        });
+
+        const titleField = screen.getByTestId("ArticlesForm-title");
+        const urlField = screen.getByTestId("ArticlesForm-url");
+        const explanationField = screen.getByTestId("ArticlesForm-explanation");
+        const emailField = screen.getByTestId("ArticlesForm-email");
+        const dateAddedField = screen.getByTestId("ArticlesForm-dateAdded");
+        const submitButton = screen.getByTestId("ArticlesForm-submit");
+
+        fireEvent.change(titleField, { target: { value: 'How to use Spring Data JDBC with Spring Boot' } });
+        fireEvent.change(urlField, { target: { value: 'https://www.youtube.com/watch?v=l_T0nQNbFiM' } });
+        fireEvent.change(explanationField, { target: { value: 'This is a great video that explains how to use Spring Data JDBC with Spring Boot' } });
+        fireEvent.change(emailField, { target: { value: 'andyouyang@ucsb.edu' } });
+        fireEvent.change(dateAddedField, { target: { value: '2022-04-21T00:00' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "title": "How to use Spring Data JDBC with Spring Boot",
+                "url": "https://www.youtube.com/watch?v=l_T0nQNbFiM",
+                "explanation": "This is a great video that explains how to use Spring Data JDBC with Spring Boot",
+                "email": "andyouyang@ucsb.edu",
+                "dateAdded": "2022-04-21T00:00"
+        });
+
+        expect(mockToast).toBeCalledWith("New article Created - id: 17 title: How to use Spring Data JDBC with Spring Boot");
+        expect(mockNavigate).toBeCalledWith({ "to": "/articles" });
     });
+
 
 });
 

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("ArticlesEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("ArticlesIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/utils/articleUtils.test.js
+++ b/frontend/src/tests/utils/articleUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/articleUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("ArticleUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/articles",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
Implemented the Create page for Articles with tests and stories

Step 1: Navigate to development link: https://team03-mumukow-dev.dokku-10.cs.ucsb.edu/

Step 2: Log in and navigate to Articles tab

![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/72269643/c59c7a8a-e7cb-493b-a338-11b9efd06f51)

Step 3: Click on Create
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/72269643/2ea5fa96-1eec-4eeb-9f51-f4decb497a6a)

Step 4: Fill in the required fields
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/72269643/81a39a14-3b0d-4022-bcae-1e3be2bfec06)

Step 5: Click Create and see if this notification appears and you're redirected to the articles index page
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/72269643/1d46b5b5-4637-450d-b78a-a02fe6b47bd8)

Step 6: Navigate to Swagger and check if the article is in the database
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/72269643/6aac04a0-2aeb-4184-b4e3-c6211f403aaf)

Storybook Link: https://ucsb-cs156-f23.github.io/team03-f23-7pm-2/prs/72/storybook
Closes #58 

