### PR TITLE
Index Page for MenuItemReview Finished 

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,0 +1,3 @@
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+ADMIN_EMAILS=phtcon@ucsb.edu

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,10 @@ import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage"
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -73,6 +77,21 @@ function App() {
             <>
               <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
               <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/menuitemreview" element={<MenuItemReviewIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/menuitemreview/edit/:id" element={<MenuItemReviewEditPage />} />
+              <Route exact path="/menuitemreview/create" element={<MenuItemReviewCreatePage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -3,7 +3,8 @@ const menuItemReviewFixtures = {
         "id": 1,
         "itemId": 33,
         "stars": 5,
-        "localDateTime": "2022-01-02T12:00:00",
+        "dateReviewed": "2022-01-02T12:00:00",
+        "reviewerEmail": "richard.@gmail.com",
         "comments": "This stinks"
     },
     menuItemReview2: [
@@ -11,21 +12,24 @@ const menuItemReviewFixtures = {
             "id": 1,
             "itemId": 50,
             "stars": -1,
-            "localDateTime": "2023-01-02T12:00:00",
+            "dateReviewed": "2023-01-02T12:00:00",
+            "reviewerEmail": "richard.@gmail.com",
             "comments": "This overly"
         },
         {
             "id": 2,
             "itemId": 5,
             "stars": 5,
-            "localDateTime": "2022-04-03T12:00:00",
+            "dateReviewed": "2022-04-03T12:00:00",
+            "reviewerEmail": "richard.@gmail.com",
             "comments": "This stinks"
         },
         {
             "id": 3,
             "itemId": 20,
             "stars": 3,
-            "localDateTime": "2022-07-04T12:00:00",
+            "dateReviewed": "2022-07-04T12:00:00",
+            "reviewerEmail": "richard.@gmail.com",
             "comments": "This massively stink s"
         }
     ],
@@ -34,7 +38,8 @@ const menuItemReviewFixtures = {
             "id": 1,
             "itemId": 33,
             "stars": 3,
-            "localDateTime": "2022-01-02T12:00:00",
+            "dateReviewed": "2022-01-02T12:00:00",
+            "reviewerEmail": "richard.@gmail.com",
             "comments": "This kinda stinks"
         }
     ]

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -9,23 +9,23 @@ const menuItemReviewFixtures = {
     menuItemReview2: [
         {
             "id": 1,
-            "itemId": 2,
-            "stars": 5,
-            "localDateTime": "2022-01-02T12:00:00",
-            "comments": "This stinks"
+            "itemId": 50,
+            "stars": -1,
+            "localDateTime": "2023-01-02T12:00:00",
+            "comments": "This overly"
         },
         {
             "id": 2,
             "itemId": 5,
             "stars": 5,
-            "localDateTime": "2022-01-02T12:00:00",
+            "localDateTime": "2022-04-03T12:00:00",
             "comments": "This stinks"
         },
         {
             "id": 3,
-            "itemId": 8,
+            "itemId": 20,
             "stars": 3,
-            "localDateTime": "2022-01-02T12:00:00",
+            "localDateTime": "2022-07-04T12:00:00",
             "comments": "This massively stinks"
         }
     ],

--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -26,12 +26,12 @@ const menuItemReviewFixtures = {
             "itemId": 20,
             "stars": 3,
             "localDateTime": "2022-07-04T12:00:00",
-            "comments": "This massively stinks"
+            "comments": "This massively stink s"
         }
     ],
     menuItemReview3: [
         {
-            "id": 4,
+            "id": 1,
             "itemId": 33,
             "stars": 3,
             "localDateTime": "2022-01-02T12:00:00",

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
@@ -21,9 +21,6 @@ function MenuItemReviewForm({ initialContents, submitAction, buttonLabel = "Crea
 
     // Stryker disable next-line Regex
     const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
-
-    // Stryker disable next-line all
-    const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
     return (
 
         <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
@@ -1,0 +1,163 @@
+import { Button, Form, Row, Col } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+function MenuItemReviewForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    // Stryker disable next-line all
+    const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+
+            <Row>
+
+                {initialContents && (
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="id">Id</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-id"
+                                id="id"
+                                type="text"
+                                {...register("id")}
+                                value={initialContents.id}
+                                disabled
+                            />
+                        </Form.Group>
+                    </Col>
+                )}
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="itemId">Item Id</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-itemId"
+                                id="itemId"
+                                type="text"
+                                isInvalid={Boolean(errors.itemId)}
+                                {...register("itemId", {
+                                    required: "Item Id is required."
+                                })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.itemId?.message}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-reviewerEmail"
+                                id="reviewerEmail"
+                                type="text"
+                                isInvalid={Boolean(errors.reviewerEmail)}
+                                {...register("reviewerEmail", {
+                                    required: "Reviewer Email is required."
+                                })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.reviewerEmail?.message}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="stars">Stars</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-stars"
+                                id="stars"
+                                type="text"
+                                isInvalid={Boolean(errors.stars)}
+                                {...register("stars", {
+                                    required: "Stars is required."
+                                })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.stars?.message}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="dateReviewed">Date Reviewed (iso format)</Form.Label>
+                        <Form.Control
+                            data-testid="MenuItemReviewForm-dateReviewed"
+                            id="dateReviewed"
+                            type="datetime-local"
+                            isInvalid={Boolean(errors.localDateTime)}
+                            {...register("dateReviewed", { required: true, pattern: isodate_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.dateReviewed && 'Date Reviewed (iso format) is required.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+            <Row>
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="comments">Comments</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-comments"
+                                id="comments"
+                                type="text"
+                                isInvalid={Boolean(errors.stars)}
+                                {...register("comments", {
+                                    required: "Comments is required."
+                                })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.comments?.message}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+                </Row>
+            <Row>
+                <Col>
+                    <Button
+                        type="submit"
+                        data-testid="MenuItemReviewForm-submit"
+                    >
+                        {buttonLabel}
+                    </Button>
+                    <Button
+                        variant="Secondary"
+                        onClick={() => navigate(-1)}
+                        data-testid="MenuItemReviewForm-cancel"
+                    >
+                        Cancel
+                    </Button>
+                </Col>
+            </Row>
+        </Form>
+
+    )
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
@@ -107,7 +107,7 @@ function MenuItemReviewForm({ initialContents, submitAction, buttonLabel = "Crea
                             data-testid="MenuItemReviewForm-dateReviewed"
                             id="dateReviewed"
                             type="datetime-local"
-                            isInvalid={Boolean(errors.localDateTime)}
+                            isInvalid={Boolean(errors.dateReviewed)}
                             {...register("dateReviewed", { required: true, pattern: isodate_regex })}
                         />
                         <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
@@ -2,12 +2,11 @@ import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 
 import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/MenuItemReviewTableUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
 export default function MenuItemReviewTable({ reviews, currentUser }) {
-
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
@@ -37,7 +36,7 @@ export default function MenuItemReviewTable({ reviews, currentUser }) {
             accessor: 'itemId',
         },
         {
-            Header: 'Reviewer Emai.',
+            Header: 'Reviewer Email',
             accessor: 'reviewerEmail',
         },
         {

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
@@ -1,0 +1,63 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function MenuItemReviewTable({ reviews, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/menuitemreview/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/menuitemreview/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Item Id',
+            accessor: 'itemId',
+        },
+        {
+            Header: 'Reviewer Emai.',
+            accessor: 'reviewerEmail',
+        },
+        {
+            Header: 'Date Reviewed',
+            accessor: 'dateReviewed',
+        },
+        {
+            Header: 'Comments',
+            accessor: 'comments',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "MenuItemReviewTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "MenuItemReviewTable"));
+    } 
+
+    return <OurTable
+        data={reviews}
+        columns={columns}
+        testid={"MenuItemReviewTable"}
+    />;
+};

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -54,6 +54,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
             {
               currentUser && currentUser.loggedIn && (
                 <>
+                  <Nav.Link as={Link} to="/menuitemreview">Menu Item Review</Nav.Link>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create Menu Item Review</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,12 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage() {
+export default function MenuItemReviewCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (review) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+      itemId: review.itemId,
+      reviewerEmail: review.reviewerEmail,
+      stars: review.stars,
+      dateReviewed: review.dateReviewed,
+      comments: review.comments
+    }
+  });
+
+  const onSuccess = (review) => {
+    console.log(review)
+    toast(`New menuItemReview Created - id: ${review.id} itemId: ${review.itemId}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/menuitemreview/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create Menu Item Review</h1>
+        <h1>Create New Menu Item Review</h1>
+
+        <MenuItemReviewForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -7,7 +7,7 @@ export default function MenuItemReviewIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
-        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/menuitemreview/create">Create</a></p>
         <p><a href="/placeholder/edit/1">Edit</a></p>
       </div>
     </BasicLayout>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,14 +1,43 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from 'main/components/MenuItemReview/MenuItemReviewTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
 export default function MenuItemReviewIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        return (
+            <Button
+                variant="primary"
+                href="/menuitemreview/create"
+                style={{ float: "right" }}
+            >
+                Create Menu Item Review 
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: reviews, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/menuitemreview/all"],
+      { method: "GET", url: "/api/menuitemreview/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/menuitemreview/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>Menu Item Review</h1>
+        <MenuItemReviewTable reviews={reviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/MenuItemReviewTableUtils.js
+++ b/frontend/src/main/utils/MenuItemReviewTableUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/menuitemreview",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm"
+import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
+
+export default {
+    title: 'components/MenuItemReview/MenuItemReviewForm',
+    component: MenuItemReviewForm
+};
+
+
+const Template = (args) => { 
+    return (
+        <MenuItemReviewForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: menuItemReviewFixtures.menuItemReview1,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/MenuItemReview/MenuItemReviewTable',
+    component: MenuItemReviewTable
+};
+
+const Template = (args) => {
+    return (
+        <MenuItemReviewTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    dates: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    dates: menuItemReviewFixtures.menuItemReview3,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    dates: menuItemReviewFixtures.menuItemReview3,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/menuitemreview', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
@@ -18,19 +18,19 @@ const Template = (args) => {
 export const Empty = Template.bind({});
 
 Empty.args = {
-    dates: []
+    reviews: []
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.args = {
-    dates: menuItemReviewFixtures.menuItemReview3,
+    reviews: menuItemReviewFixtures.menuItemReview2,
     currentUser: currentUserFixtures.userOnly,
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.args = {
-    dates: menuItemReviewFixtures.menuItemReview3,
+    reviews: menuItemReviewFixtures.menuItemReview2,
     currentUser: currentUserFixtures.adminUser,
 }
 

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+
+export default {
+    title: 'pages/MenuItemReview/MenuItemReviewCreatePage',
+    component: MenuItemReviewCreatePage
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/menuitemreview/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.js
@@ -1,0 +1,66 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+export default {
+    title: 'pages/MenuItemReview/MenuItemReviewIndexPage',
+    component: MenuItemReviewIndexPage
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/menuitemreview/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/menuitemreview/all', (_req, res, ctx) => {
+            return res(ctx.json(menuItemReviewFixtures.menuItemReview2));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/menuitemreview/all', (_req, res, ctx) => {
+            return res(ctx.json(menuItemReviewFixtures.menuItemReview2));
+        }),
+        rest.delete('/api/menuitemreview', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
@@ -1,0 +1,139 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("MenuItemReviewForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByText(/Item Id/);
+        await screen.findByText(/Create/);
+    });
+
+
+    test("renders correctly when passing in a MenuItemReview", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm initialContents={menuItemReviewFixtures.menuItemReview1} />
+            </Router>
+        );
+        await screen.findByTestId(/MenuItemReviewForm-id/);
+        expect(screen.getByText(/^Id$/)).toBeInTheDocument();
+        expect(screen.getByTestId(/MenuItemReviewForm-id/)).toHaveValue("1");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-itemId");
+
+        const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+        const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+        const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.change(itemIdField, { target: { value: 'bad-input' } });
+        fireEvent.change(reviewerEmailField, { target: { value: 'bad-input' } });
+        fireEvent.change(starsField, { target: { value: 'bad-input' } });
+        fireEvent.change(dateReviewedField, { target: { value: 'bad-input' } });
+        fireEvent.change(commentsField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        // await screen.findByText(/QuarterYYYYQ must be in the format YYYYQ/);
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-submit");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.click(submitButton);
+        // console.log(screen.getByTestId("MenuItemReviewForm-dateReviewed").innerHTML)
+        await screen.findByText(/Item Id is required./);
+        expect(screen.getByText(/Reviewer Email is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Stars is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Date Reviewed \(iso format\) is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Comments is required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <MenuItemReviewForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-itemId");
+
+        const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+        const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+        const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.change(itemIdField, { target: { value: '1' } });
+        fireEvent.change(reviewerEmailField, { target: { value: 'cgaucho@ucsb.edu' } });
+        fireEvent.change(starsField, { target: { value: '5' } });
+        fireEvent.change(dateReviewedField, { target: { value: '2022-01-02T12:00' } });
+        fireEvent.change(commentsField, { target: { value: 'Amazing!' } });
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/dateReviewed must be in ISO format/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-cancel");
+        const cancelButton = screen.getByTestId("MenuItemReviewForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
@@ -1,0 +1,122 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Item Id", "Reviewer Email", "Date Reviewed", "Comments"];
+    const expectedFields = ["id", "itemId", "reviewerEmail", "dateReviewed", "comments"];
+    const testId = "MenuItemReviewTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Item Id", "Reviewer Email", "Date Reviewed", "Comments"];
+    const expectedFields = ["id", "itemId", "reviewerEmail", "dateReviewed", "comments"];
+    const testId = "MenuItemReviewTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`MenuItemReviewTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const editButton = screen.getByTestId(`MenuItemReviewTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/menuitemreview/edit/1'));
+
+  });
+
+});
+

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
 
 const mockedNavigate = jest.fn();
@@ -23,9 +23,9 @@ describe("UserTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.menuItemReview2} currentUser={currentUser} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider> 
 
     );
 
@@ -54,14 +54,14 @@ describe("UserTable tests", () => {
 
   });
 
-  test("Has the expected colum headers and content for adminUser", () => {
+  test("Has the expected column headers and content for adminUser", () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.menuItemReview2} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -80,9 +80,8 @@ describe("UserTable tests", () => {
       const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
-
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2"); 
 
     const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
@@ -101,7 +100,7 @@ describe("UserTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <MenuItemReviewTable dates={menuItemReviewFixtures.menuItemReview3} currentUser={currentUser} />
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.menuItemReview2} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
@@ -115,7 +115,36 @@ describe("UserTable tests", () => {
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/menuitemreview/edit/1'));
 
+
   });
 
-});
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+    const testId = "MenuItemReviewTable";
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.menuItemReview2} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-itemId`)).toHaveTextContent("50");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+
+
+
+
+
+  });
 

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemReviewCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,62 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("MenuItemReviewCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const menuItemReview = {
+            "id": "17",
+            "itemId": "1",
+            "stars": "5",
+            "dateReviewed": "2022-01-02T13:00",
+            "reviewerEmail": "cgaucho@ucsb.edu",
+            "comments": "Amazing!"
+        };
+
+        axiosMock.onPost("/api/menuitemreview/post").reply( 202, menuItemReview );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,9 +72,44 @@ describe("MenuItemReviewCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("MenuItemReviewForm-itemId")).toBeInTheDocument();
+        });
+
+       
+        const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+        const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+        const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+      
+        fireEvent.change(itemIdField, { target: { value: '1' } });
+        fireEvent.change(reviewerEmailField, { target: { value: 'cgaucho@ucsb.edu' } });
+        fireEvent.change(starsField, { target: { value: '5' } });
+        fireEvent.change(dateReviewedField, { target: { value: '2022-01-02T13:00' } });
+        fireEvent.change(commentsField, { target: { value: 'Amazing!' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "itemId": "1",
+                "stars": "5",
+                "dateReviewed": "2022-01-02T13:00",
+                "reviewerEmail": "cgaucho@ucsb.edu",
+                "comments": "Amazing!"
+        });
+
+        expect(mockToast).toBeCalledWith("New menuItemReview Created - id: 17 itemId: 1");
+        expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreview" });
     });
+
 
 });
 

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("MenuItemReviewEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("MenuItemReviewIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,17 +1,32 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("MenuItemReviewIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "MenuItemReviewTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +35,18 @@ describe("MenuItemReviewIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
 
         // act
         render(
@@ -36,9 +58,97 @@ describe("MenuItemReviewIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Menu Item Review/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Menu Item Review/);
+        expect(button).toHaveAttribute("href", "/menuitemreview/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three menu item reviews correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.menuItemReview2);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create Menu Item Review/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").timeout();
+        const restoreConsole = mockConsole();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/menuitemreview/all");
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.menuItemReview2);
+        axiosMock.onDelete("/api/menuitemreview").reply(200, "MenuItemReview with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert 
+        await waitFor(() => { expect(mockToast).toBeCalledWith("MenuItemReview with id 1 was deleted") });
+
     });
 
 });

--- a/frontend/src/tests/utils/MenuItemReviewTableUtils.test.js
+++ b/frontend/src/tests/utils/MenuItemReviewTableUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/MenuItemReviewTableUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("MenuItemReviewUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/menuitemreview",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
Finished Index Page with tests and storybook

[Go to my dokku deployment and login](https://team03-huangderful-dev.dokku-10.cs.ucsb.edu/)

Go to Menu Item Review at the top, this should navigate you to the index page. 

<img width="1330" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/91812464/71af07ec-047d-4fd2-929a-b0b5c9080580">

If there isn't one in the table, create an item. Click edit. This should take you to the correct URL with an UNimplemented edit page. 

<img width="1332" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/91812464/b94f879d-b878-4fbf-9ba9-6442b0261b4d">

Navigate back to index and click delete. This should remove the row.
<img width="1330" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/91812464/eb8cee73-c095-43ae-80d4-21cb8000b154">

Navigate to swagger and run a menuitemreview get all to verify that the item was deleted. 

<img width="1332" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-2/assets/91812464/0bcb6e0c-dfb5-4a2b-8315-02e41e17ef92">


Storybook link: https://ucsb-cs156-f23.github.io/team03-f23-7pm-2/prs/103/storybook/?path=/story/pages-menuitemreview-menuitemreviewindexpage--empty

Closes #41 

